### PR TITLE
Accept an external instance (v1.3.0)

### DIFF
--- a/examples/externalInstance.md
+++ b/examples/externalInstance.md
@@ -1,0 +1,34 @@
+
+# Using an external SDK instance
+
+If you need access to the SDK instance, using the npm package v1.3.0+ you can pass a promise to the `useSdk` function, but you will need to handle authorization and authentication as documented here:
+
+https://discord.com/developers/docs/activities/how-activities-work#sample-code-and-activity-lifecycle-diagram
+
+---
+
+`index.ts`
+
+```ts
+import { useSdk, DiscordSDK, DataPromise } from "dissonity";
+
+window.addEventListener("DOMContentLoaded", async () => {
+
+    const discordSdk = new DiscordSDK(/* Client id */);
+
+    const promise: DataPromise = new Promise(async resolve => {
+    
+        await discordSdk.ready();
+  
+        // (Authorization process...)
+  
+        const { user } = await discordSdk.commands.authenticate({
+            access_token: /* Retrieved access token */,
+        });
+
+        resolve({ discordSdk, user });
+    });
+
+    useSdk(promise);
+});
+```

--- a/examples/node_project/package-lock.json
+++ b/examples/node_project/package-lock.json
@@ -11,9 +11,9 @@
       "dependencies": {
         "@colyseus/schema": "^2.0.30",
         "@colyseus/ws-transport": "^0.15.1",
-        "colyseus": "^0.15.15",
+        "colyseus": "^0.15.13",
         "cross-fetch": "^3.1.5",
-        "dissonity": "^1.2.3",
+        "dissonity": "^1.3.0",
         "dotenv": "^16.0.3",
         "esbuild": "0.17.11",
         "express": "^4.18.2"
@@ -23,29 +23,6 @@
         "@types/node": "^20.12.5",
         "glob": "^9.2.1",
         "typescript": "^5.2.2"
-      }
-    },
-    "node_modules/@colyseus/auth": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/@colyseus/auth/-/auth-0.15.10.tgz",
-      "integrity": "sha512-2RsbqtS2WTsjDlY5BDxpjC4OGm0HvvaNlZYMPGLD5vN8gJoQGnU9SEl1OWmcvlrxqFY0tEk1d4Wux10G4U8ifw==",
-      "dependencies": {
-        "@types/jsonwebtoken": "^9.0.5",
-        "connect-redis": "^7.1.0",
-        "express-jwt": "^8.4.1",
-        "express-session": "^1.17.3",
-        "grant": "^5.4.22",
-        "jsonwebtoken": "^9.0.0"
-      },
-      "engines": {
-        "node": ">= 14.x"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/endel"
-      },
-      "peerDependencies": {
-        "@colyseus/core": "^0.15.23",
-        "express": "^4.17.1"
       }
     },
     "node_modules/@colyseus/core": {
@@ -221,18 +198,10 @@
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
       "dev": true
     },
-    "node_modules/@types/jsonwebtoken": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.6.tgz",
-      "integrity": "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/lodash": {
-      "version": "4.17.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.9.tgz",
-      "integrity": "sha512-w9iWudx1XWOHW5lQRS9iKpK/XuRhnN+0T7HvdCCd802FYkT1AMTnxndJHGrNJwRoRHkslGr4S29tjm1cT7x/7w=="
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.12.tgz",
+      "integrity": "sha512-sviUmCE8AYdaF/KIHLDJBQgeYzPBI0vf/17NaYehBJfYD1j6/L95Slh07NlyK2iNyBNaEkb3En2jRt+a8y3xZQ=="
     },
     "node_modules/@types/lodash.transform": {
       "version": "4.6.9",
@@ -319,18 +288,6 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
-    "node_modules/asn1.js": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-      "optional": true,
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -344,12 +301,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-      "optional": true
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -396,17 +347,6 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-      "optional": true
-    },
-    "node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -442,29 +382,17 @@
       }
     },
     "node_modules/colyseus": {
-      "version": "0.15.17",
-      "resolved": "https://registry.npmjs.org/colyseus/-/colyseus-0.15.17.tgz",
-      "integrity": "sha512-9RDi8fbikCQ8tb9ptNQ0MBsP3dOR9ltxQGhkg6f0RGnQ+tkzcXEfwtIuO6nbGJm75bmSFPmRH40uoG6qlvBlIw==",
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/colyseus/-/colyseus-0.15.13.tgz",
+      "integrity": "sha512-sPFzsVbO1zwo8bm+3aLeC75R4+KoKTKq2NniGbIoLT0fVOmYszxgrZ/2BuaNApCgKc3hiR12KZmOC7+b7jij/w==",
       "dependencies": {
-        "@colyseus/auth": "^0.15.10",
-        "@colyseus/core": "^0.15.36",
-        "@colyseus/redis-driver": "^0.15.6",
-        "@colyseus/redis-presence": "^0.15.5",
+        "@colyseus/core": "^0.15.13",
+        "@colyseus/redis-driver": "^0.15.3",
+        "@colyseus/redis-presence": "^0.15.2",
         "@colyseus/ws-transport": "^0.15.1"
       },
       "engines": {
         "node": ">= 14.x"
-      }
-    },
-    "node_modules/connect-redis": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-7.1.1.tgz",
-      "integrity": "sha512-M+z7alnCJiuzKa8/1qAYdGUXHYfDnLolOGAUjOioB07pP39qxjG+X9ibsud7qUBc4jMV5Mcy3ugGv8eFcgamJQ==",
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "express-session": ">=1"
       }
     },
     "node_modules/content-disposition": {
@@ -487,9 +415,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -579,11 +507,11 @@
       }
     },
     "node_modules/dissonity": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/dissonity/-/dissonity-1.2.3.tgz",
-      "integrity": "sha512-nbn+HUcSOblrPsG7cFhBThC8sy7LIyObRmCNhLVkN0/y9mNB8TsYTiRJhHg8o5DRXsTEw4YjRqqMVYXmqAoV+Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/dissonity/-/dissonity-1.3.0.tgz",
+      "integrity": "sha512-ehx+9e2DtwSODyC/5R5HhWJmm9XBPj+DYhgNYFN3oCFDyv/5lMEwb8MlThxMsB77RmozmmBkXOCmpkXoEizSMw==",
       "dependencies": {
-        "@discord/embedded-app-sdk": "^1.4.0",
+        "@discord/embedded-app-sdk": "^1.5.0",
         "cross-fetch": "^4.0.0"
       }
     },
@@ -606,33 +534,10 @@
         "url": "https://dotenvx.com"
       }
     },
-    "node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
-    },
-    "node_modules/elliptic": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
-      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
-      "optional": true,
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -716,16 +621,16 @@
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -755,60 +660,6 @@
       "engines": {
         "node": ">= 0.10.0"
       }
-    },
-    "node_modules/express-jwt": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-8.4.1.tgz",
-      "integrity": "sha512-IZoZiDv2yZJAb3QrbaSATVtTCYT11OcqgFGoTN4iKVyN6NBkBkhtVIixww5fmakF0Upt5HfOxJuS6ZmJVeOtTQ==",
-      "dependencies": {
-        "@types/jsonwebtoken": "^9",
-        "express-unless": "^2.1.3",
-        "jsonwebtoken": "^9.0.0"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/express-session": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.0.tgz",
-      "integrity": "sha512-m93QLWr0ju+rOwApSsyso838LQwgfs44QtOP/WBiwtAgPIo/SAh1a5c6nn2BR6mFNZehTpqKDESzP+fRHVbxwQ==",
-      "dependencies": {
-        "cookie": "0.6.0",
-        "cookie-signature": "1.0.7",
-        "debug": "2.6.9",
-        "depd": "~2.0.0",
-        "on-headers": "~1.0.2",
-        "parseurl": "~1.3.3",
-        "safe-buffer": "5.2.1",
-        "uid-safe": "~2.1.5"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/express-session/node_modules/cookie-signature": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
-    },
-    "node_modules/express-session/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/express-session/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/express-unless": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/express-unless/-/express-unless-2.1.3.tgz",
-      "integrity": "sha512-wj4tLMyCVYuIIKHGt0FhCtIViBcwzWejX0EjNxveAa6dG+0XBCQhMbx+PnkLkFCxLC69qoFrxds4pIyL88inaQ=="
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
@@ -930,43 +781,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/grant": {
-      "version": "5.4.22",
-      "resolved": "https://registry.npmjs.org/grant/-/grant-5.4.22.tgz",
-      "integrity": "sha512-DEi+/JjXT84mmFYhSmv+SX14v+3Z7vuCIYAMwtdPCTXHMSLhWqSYqWAMXDUQZuV7yaJv2d84AYnkCFNooLKBsA==",
-      "dependencies": {
-        "qs": "^6.11.2",
-        "request-compose": "^2.1.6",
-        "request-oauth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "optionalDependencies": {
-        "cookie": "^0.5.0",
-        "cookie-signature": "^1.2.1",
-        "jwk-to-pem": "^2.0.5",
-        "jws": "^4.0.0"
-      }
-    },
-    "node_modules/grant/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/grant/node_modules/cookie-signature": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.1.tgz",
-      "integrity": "sha512-78KWk9T26NhzXtuL26cIJ8/qNHANyJ/ZYrmEXFzUmhZdjpBv+DlWlOANRTGBt48YcyslsLrj0bMLFTmXvLRCOw==",
-      "optional": true,
-      "engines": {
-        "node": ">=6.6.0"
-      }
-    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -1000,16 +814,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -1019,17 +823,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-      "optional": true,
-      "dependencies": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/http-errors": {
@@ -1094,122 +887,15 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-      "dependencies": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "dependencies": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jwa": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-      "optional": true,
-      "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jwk-to-pem": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.5.tgz",
-      "integrity": "sha512-L90jwellhO8jRKYwbssU9ifaMVqajzj3fpRjDKcsDzrslU9syRbFqfkXtT4B89HYAap+xsxNcxgBSB09ig+a7A==",
-      "optional": true,
-      "dependencies": {
-        "asn1.js": "^5.3.0",
-        "elliptic": "^6.5.4",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-      "optional": true,
-      "dependencies": {
-        "jwa": "^2.0.0",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
     },
-    "node_modules/lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
-    },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
-    },
-    "node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
-    },
-    "node_modules/lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
-    },
-    "node_modules/lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
-    },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
-    },
-    "node_modules/lodash.once": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/lodash.transform": {
       "version": "4.6.0",
@@ -1275,18 +961,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "optional": true
-    },
-    "node_modules/minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-      "optional": true
     },
     "node_modules/minimatch": {
       "version": "8.0.4",
@@ -1392,14 +1066,6 @@
         "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
@@ -1418,14 +1084,6 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -1494,14 +1152,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/random-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -1543,35 +1193,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/request-compose": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/request-compose/-/request-compose-2.1.6.tgz",
-      "integrity": "sha512-S07L+2VbJB32WddD/o/PnYGKym63zLVbymygVWXvt8L79VAngcjAxhHaGuFOICLxEV90EasEPzqPKKHPspXP8w==",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/request-oauth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/request-oauth/-/request-oauth-1.0.1.tgz",
-      "integrity": "sha512-85THTg1RgOYtqQw42JON6AqvHLptlj1biw265Tsq4fD4cPdUvhDB2Qh9NTv17yCD322ROuO9aOmpc4GyayGVBA==",
-      "dependencies": {
-        "oauth-sign": "^0.9.0",
-        "qs": "^6.9.6",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/request-oauth/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1595,17 +1216,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/send": {
       "version": "0.19.0",
@@ -1757,17 +1367,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/uid-safe": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-      "dependencies": {
-        "random-bytes": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/undici-types": {

--- a/examples/node_project/package.json
+++ b/examples/node_project/package.json
@@ -12,9 +12,9 @@
   "dependencies": {
     "@colyseus/schema": "^2.0.30",
     "@colyseus/ws-transport": "^0.15.1",
-    "colyseus": "^0.15.15",
+    "colyseus": "^0.15.13",
     "cross-fetch": "^3.1.5",
-    "dissonity": "^1.2.3",
+    "dissonity": "^1.3.0",
     "dotenv": "^16.0.3",
     "esbuild": "0.17.11",
     "express": "^4.18.2"

--- a/examples/node_project/src/_pnpm/pnpm-lock.yaml
+++ b/examples/node_project/src/_pnpm/pnpm-lock.yaml
@@ -12,14 +12,14 @@ dependencies:
     specifier: ^0.15.1
     version: 0.15.2(@colyseus/schema@2.0.35)
   colyseus:
-    specifier: ^0.15.15
-    version: 0.15.17(@colyseus/schema@2.0.35)(express@4.21.0)
+    specifier: ^0.15.13
+    version: 0.15.17(@colyseus/schema@2.0.35)(express@4.21.1)
   cross-fetch:
     specifier: ^3.1.5
     version: 3.1.8
   dissonity:
-    specifier: ^1.2.3
-    version: 1.2.3
+    specifier: ^1.3.0
+    version: 1.3.0
   dotenv:
     specifier: ^16.0.3
     version: 16.4.5
@@ -28,7 +28,7 @@ dependencies:
     version: 0.17.11
   express:
     specifier: ^4.18.2
-    version: 4.21.0
+    version: 4.21.1
 
 devDependencies:
   '@types/express':
@@ -36,37 +36,37 @@ devDependencies:
     version: 4.17.21
   '@types/node':
     specifier: ^20.12.5
-    version: 20.16.10
+    version: 20.16.13
   glob:
     specifier: ^9.2.1
     version: 9.3.5
   typescript:
     specifier: ^5.2.2
-    version: 5.6.2
+    version: 5.6.3
 
 packages:
 
-  /@colyseus/auth@0.15.10(@colyseus/core@0.15.51)(express@4.21.0):
+  /@colyseus/auth@0.15.10(@colyseus/core@0.15.53)(express@4.21.1):
     resolution: {integrity: sha512-2RsbqtS2WTsjDlY5BDxpjC4OGm0HvvaNlZYMPGLD5vN8gJoQGnU9SEl1OWmcvlrxqFY0tEk1d4Wux10G4U8ifw==}
     engines: {node: '>= 14.x'}
     peerDependencies:
       '@colyseus/core': ^0.15.23
       express: ^4.17.1
     dependencies:
-      '@colyseus/core': 0.15.51
+      '@colyseus/core': 0.15.53
       '@types/jsonwebtoken': 9.0.7
-      connect-redis: 7.1.1(express-session@1.18.0)
-      express: 4.21.0
+      connect-redis: 7.1.1(express-session@1.18.1)
+      express: 4.21.1
       express-jwt: 8.4.1
-      express-session: 1.18.0
+      express-session: 1.18.1
       grant: 5.4.23
       jsonwebtoken: 9.0.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@colyseus/core@0.15.51:
-    resolution: {integrity: sha512-Y4Aso/GFO/XLyg7J5rv7qLmR8dC+AixMA0FsE8Yar3v++H1YJAnkqmzbzO4tyZ2vXXhcwzlGgo+op1OzZ7199w==}
+  /@colyseus/core@0.15.53:
+    resolution: {integrity: sha512-09tcOCZTCDL/o0uo7ysz3HjW7EYiAFIDNstCSMGX0ua/Ul+gQj9YO8J43rRZIe3vKExHtrWm0zOU2uquhRjY1A==}
     engines: {node: '>= 14.x'}
     dependencies:
       '@colyseus/greeting-banner': 2.0.2
@@ -89,7 +89,7 @@ packages:
   /@colyseus/redis-driver@0.15.6:
     resolution: {integrity: sha512-nLNb1/e0KcK3wgVX1DQdC+bV86BIJWlVtxDrQW23aED+4ih6fIr0Iwfre3DlSke+DXa8oGwp5n3/s7A62q/4gQ==}
     dependencies:
-      '@colyseus/core': 0.15.51
+      '@colyseus/core': 0.15.53
       ioredis: 5.4.1
     transitivePeerDependencies:
       - bufferutil
@@ -100,7 +100,7 @@ packages:
   /@colyseus/redis-presence@0.15.5:
     resolution: {integrity: sha512-ClJDPMP1JZlemuGMmefrW2QPmfdz2Po6FMJ9Ln/EQ9UvEdrFpgylCzOgbKzMyZ4BQFRDlnIy8lE/WUZ4Yb7Sfw==}
     dependencies:
-      '@colyseus/core': 0.15.51
+      '@colyseus/core': 0.15.53
       ioredis: 5.4.1
     transitivePeerDependencies:
       - bufferutil
@@ -118,7 +118,7 @@ packages:
     peerDependencies:
       '@colyseus/schema': '>=1.0.0'
     dependencies:
-      '@colyseus/core': 0.15.51
+      '@colyseus/core': 0.15.53
       '@colyseus/schema': 2.0.35
       '@types/ws': 7.4.7
       ws: 7.5.10
@@ -405,19 +405,19 @@ packages:
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.16.10
+      '@types/node': 20.16.13
     dev: true
 
   /@types/connect@3.4.38:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
-      '@types/node': 20.16.10
+      '@types/node': 20.16.13
     dev: true
 
   /@types/express-serve-static-core@4.19.6:
     resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
     dependencies:
-      '@types/node': 20.16.10
+      '@types/node': 20.16.13
       '@types/qs': 6.9.16
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -439,25 +439,25 @@ packages:
   /@types/jsonwebtoken@9.0.7:
     resolution: {integrity: sha512-ugo316mmTYBl2g81zDFnZ7cfxlut3o+/EQdaP7J8QN2kY6lJ22hmQYCK5EHcJHbrW+dkCGSCPgbG8JtYj6qSrg==}
     dependencies:
-      '@types/node': 20.16.10
+      '@types/node': 20.16.13
     dev: false
 
   /@types/lodash.transform@4.6.9:
     resolution: {integrity: sha512-1iIn+l7Vrj8hsr2iZLtxRkcV9AtjTafIyxKO9DX2EEcdOgz3Op5dhwKQFhMJgdfIRbYHBUF+SU97Y6P+zyLXNg==}
     dependencies:
-      '@types/lodash': 4.17.9
+      '@types/lodash': 4.17.12
     dev: false
 
-  /@types/lodash@4.17.9:
-    resolution: {integrity: sha512-w9iWudx1XWOHW5lQRS9iKpK/XuRhnN+0T7HvdCCd802FYkT1AMTnxndJHGrNJwRoRHkslGr4S29tjm1cT7x/7w==}
+  /@types/lodash@4.17.12:
+    resolution: {integrity: sha512-sviUmCE8AYdaF/KIHLDJBQgeYzPBI0vf/17NaYehBJfYD1j6/L95Slh07NlyK2iNyBNaEkb3En2jRt+a8y3xZQ==}
     dev: false
 
   /@types/mime@1.3.5:
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
     dev: true
 
-  /@types/node@20.16.10:
-    resolution: {integrity: sha512-vQUKgWTjEIRFCvK6CyriPH3MZYiYlNy0fKiEYHWbcoWLEgs4opurGGKlebrTLqdSMIbXImH6XExNiIyNUv3WpA==}
+  /@types/node@20.16.13:
+    resolution: {integrity: sha512-GjQ7im10B0labo8ZGXDGROUl9k0BNyDgzfGpb4g/cl+4yYDWVKcozANF4FGr4/p0O/rAkQClM6Wiwkije++1Tg==}
     dependencies:
       undici-types: 6.19.8
 
@@ -473,14 +473,14 @@ packages:
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.16.10
+      '@types/node': 20.16.13
     dev: true
 
   /@types/serve-static@1.15.7:
     resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 20.16.10
+      '@types/node': 20.16.13
       '@types/send': 0.17.4
     dev: true
 
@@ -491,7 +491,7 @@ packages:
   /@types/ws@7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
     dependencies:
-      '@types/node': 20.16.10
+      '@types/node': 20.16.13
     dev: false
 
   /accepts@1.3.8:
@@ -589,12 +589,12 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /colyseus@0.15.17(@colyseus/schema@2.0.35)(express@4.21.0):
+  /colyseus@0.15.17(@colyseus/schema@2.0.35)(express@4.21.1):
     resolution: {integrity: sha512-9RDi8fbikCQ8tb9ptNQ0MBsP3dOR9ltxQGhkg6f0RGnQ+tkzcXEfwtIuO6nbGJm75bmSFPmRH40uoG6qlvBlIw==}
     engines: {node: '>= 14.x'}
     dependencies:
-      '@colyseus/auth': 0.15.10(@colyseus/core@0.15.51)(express@4.21.0)
-      '@colyseus/core': 0.15.51
+      '@colyseus/auth': 0.15.10(@colyseus/core@0.15.53)(express@4.21.1)
+      '@colyseus/core': 0.15.53
       '@colyseus/redis-driver': 0.15.6
       '@colyseus/redis-presence': 0.15.5
       '@colyseus/ws-transport': 0.15.2(@colyseus/schema@2.0.35)
@@ -606,13 +606,13 @@ packages:
       - utf-8-validate
     dev: false
 
-  /connect-redis@7.1.1(express-session@1.18.0):
+  /connect-redis@7.1.1(express-session@1.18.1):
     resolution: {integrity: sha512-M+z7alnCJiuzKa8/1qAYdGUXHYfDnLolOGAUjOioB07pP39qxjG+X9ibsud7qUBc4jMV5Mcy3ugGv8eFcgamJQ==}
     engines: {node: '>=16'}
     peerDependencies:
       express-session: '>=1'
     dependencies:
-      express-session: 1.18.0
+      express-session: 1.18.1
     dev: false
 
   /content-disposition@0.5.4:
@@ -644,6 +644,18 @@ packages:
 
   /cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /cookie@0.7.1:
+    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -721,8 +733,8 @@ packages:
     dev: false
     optional: true
 
-  /dissonity@1.2.3:
-    resolution: {integrity: sha512-nbn+HUcSOblrPsG7cFhBThC8sy7LIyObRmCNhLVkN0/y9mNB8TsYTiRJhHg8o5DRXsTEw4YjRqqMVYXmqAoV+Q==}
+  /dissonity@1.3.0:
+    resolution: {integrity: sha512-ehx+9e2DtwSODyC/5R5HhWJmm9XBPj+DYhgNYFN3oCFDyv/5lMEwb8MlThxMsB77RmozmmBkXOCmpkXoEizSMw==}
     dependencies:
       '@discord/embedded-app-sdk': 1.5.0
       cross-fetch: 4.0.0
@@ -833,11 +845,11 @@ packages:
       jsonwebtoken: 9.0.2
     dev: false
 
-  /express-session@1.18.0:
-    resolution: {integrity: sha512-m93QLWr0ju+rOwApSsyso838LQwgfs44QtOP/WBiwtAgPIo/SAh1a5c6nn2BR6mFNZehTpqKDESzP+fRHVbxwQ==}
+  /express-session@1.18.1:
+    resolution: {integrity: sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==}
     engines: {node: '>= 0.8.0'}
     dependencies:
-      cookie: 0.6.0
+      cookie: 0.7.2
       cookie-signature: 1.0.7
       debug: 2.6.9
       depd: 2.0.0
@@ -853,8 +865,8 @@ packages:
     resolution: {integrity: sha512-wj4tLMyCVYuIIKHGt0FhCtIViBcwzWejX0EjNxveAa6dG+0XBCQhMbx+PnkLkFCxLC69qoFrxds4pIyL88inaQ==}
     dev: false
 
-  /express@4.21.0:
-    resolution: {integrity: sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==}
+  /express@4.21.1:
+    resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
     engines: {node: '>= 0.10.0'}
     dependencies:
       accepts: 1.3.8
@@ -862,7 +874,7 @@ packages:
       body-parser: 1.20.3
       content-disposition: 0.5.4
       content-type: 1.0.5
-      cookie: 0.6.0
+      cookie: 0.7.1
       cookie-signature: 1.0.6
       debug: 2.6.9
       depd: 2.0.0
@@ -1475,8 +1487,8 @@ packages:
       mime-types: 2.1.35
     dev: false
 
-  /typescript@5.6.2:
-    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
+  /typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true

--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.0 - 2024-xx-xx
+
+### Added
+
+- Support for using an external SDK instance
+
 ## 1.2.3 - 2024-10-02
 
 ### Fixed

--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.3.0 - 2024-xx-xx
+## 1.3.0 - 2024-10-21
 
 ### Added
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -8,7 +8,7 @@
 
 # About
 
-Dissonity allows you to easily create Discord activities with Unity. The npm and Unity packages share data to provide functionality.
+Dissonity allows you to easily create Discord activities with Unity. In version 1, the npm and Unity packages share data to provide functionality.
 
 It's designed for a structure similar to the [nested-messages](https://github.com/discord/embedded-app-sdk/tree/main/examples/nested-messages) example from Discord. You may want to familiarize with that project structure first.
 
@@ -25,7 +25,7 @@ pnpm add dissonity
 When running the activity, your game build will be inside a nested iframe that we will call "child".
 The child iframe must have the id "dissonity-child", like:
 ```html
-<iframe id="dissonity-child" src="nested/index.html"></iframe>
+<iframe id="dissonity-child" src=".proxy/nested/index.html"></iframe>
 ```
 Instead of manually creating an SDK instance, call `setupSdk` inside the parent index.js with your options:
 
@@ -77,3 +77,4 @@ That's all the configuration you need inside Node.js! Now, in your Unity project
 - [NPM Package Source](https://github.com/Furnyr/Dissonity/tree/main/npm)
 - [Unity Package](https://github.com/Furnyr/Dissonity/tree/main/unity#readme)
 - [Unity Package Documentation](https://github.com/Furnyr/Dissonity/blob/main/unity/Documentation~/Dissonity.md)
+- [Examples](https://github.com/Furnyr/Dissonity/tree/main/examples)

--- a/npm/index.ts
+++ b/npm/index.ts
@@ -1,1 +1,2 @@
-export { setupSdk } from "./src/functions";
+export { setupSdk, useSdk, DiscordSDK } from "./src/functions";
+export type { DataPromise } from "./src/types";

--- a/npm/package.json
+++ b/npm/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Furnyr/Dissonity#readme",
   "dependencies": {
-    "@discord/embedded-app-sdk": "^1.4.0",
+    "@discord/embedded-app-sdk": "^1.5.0",
     "cross-fetch": "^4.0.0"
   },
   "devDependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dissonity",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Extension of the Discord Embedded App SDK that allows you to create activities alongside the Dissonity v1 Unity package",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/npm/pnpm-lock.yaml
+++ b/npm/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@discord/embedded-app-sdk':
-    specifier: ^1.4.0
-    version: 1.4.0
+    specifier: ^1.5.0
+    version: 1.5.0
   cross-fetch:
     specifier: ^4.0.0
     version: 4.0.0
@@ -25,8 +25,8 @@ devDependencies:
 
 packages:
 
-  /@discord/embedded-app-sdk@1.4.0:
-    resolution: {integrity: sha512-R+xyr5WNNTulSZrhvRQURKtd0Q/mm0ghjMHGnMWyimrKB0UJ0c6K9YbSZZgN/lADJSJiqEW+PEpvvzd3Ldxkfw==}
+  /@discord/embedded-app-sdk@1.5.0:
+    resolution: {integrity: sha512-3BeDBEiioQwPR5hWf43twAd+2zGi3emRDTnYFF8QIl7GOmJ+XNb53WLB7Mr1Rds+wjus1TaRGkxQ+XeDDaiBKQ==}
     dependencies:
       '@types/lodash.transform': 4.6.9
       '@types/uuid': 10.0.0
@@ -442,11 +442,11 @@ packages:
   /@types/lodash.transform@4.6.9:
     resolution: {integrity: sha512-1iIn+l7Vrj8hsr2iZLtxRkcV9AtjTafIyxKO9DX2EEcdOgz3Op5dhwKQFhMJgdfIRbYHBUF+SU97Y6P+zyLXNg==}
     dependencies:
-      '@types/lodash': 4.17.7
+      '@types/lodash': 4.17.12
     dev: false
 
-  /@types/lodash@4.17.7:
-    resolution: {integrity: sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==}
+  /@types/lodash@4.17.12:
+    resolution: {integrity: sha512-sviUmCE8AYdaF/KIHLDJBQgeYzPBI0vf/17NaYehBJfYD1j6/L95Slh07NlyK2iNyBNaEkb3En2jRt+a8y3xZQ==}
     dev: false
 
   /@types/node@20.12.7:

--- a/npm/src/functions.ts
+++ b/npm/src/functions.ts
@@ -2,11 +2,13 @@
 import { DiscordSDK } from "@discord/embedded-app-sdk";
 import fetch from "cross-fetch";
 
-import type { ConfigOptions, CompatibleUser, MessageData, MessageParentCommand, DiscordSDKEvents } from "./types";
+import type { ConfigOptions, CompatibleUser, MessageData, MessageParentCommand, DiscordSDKEvents, DataPromise } from "./types";
 
-// The package version is 1.2.x, but this minor change
+// The package version is 1.3.x, but these changes
 // only affects the NPM side and it's completely compatible with Dissonity Unity 1.1.x
-const PACKAGE_VERSION = "1.1.5";
+const PACKAGE_VERSION = "1.1.6";
+
+let initialized = false;
 
 
 //* Stringifies JSON with BigInts
@@ -81,8 +83,294 @@ async function initializeSdk(options: ConfigOptions): Promise<{ discordSdk: Disc
     return { discordSdk, user: (user as CompatibleUser) };
 }
 
+//\ Handle received message
+async function receiveMessage(discordSdk: DiscordSDK, user: CompatibleUser, messageData: MessageData) {
+
+    const { nonce, event, command } = messageData;
+    let { args } = messageData;
+
+    // Sends a message to child iframe
+    function handleSubscribeEvent(eventData: Record<string, unknown>) {
+
+        getChildIframe().contentWindow?.postMessage(
+            {
+                event,
+                command: "DISPATCH",
+                data: eventData,
+            },
+            "*"
+        );
+    }
+
+    // Handle the command
+    switch (command as MessageParentCommand) {
+
+        case "SUBSCRIBE": {
+
+            if (event == null) {
+                throw new Error("SUBSCRIBE event is undefined");
+            }
+
+            //? Use channel id
+            if (args.channel_id) args = { channel_id: discordSdk!.channelId };
+
+            try {
+                discordSdk!.subscribe(event as DiscordSDKEvents, handleSubscribeEvent, args as any);
+            } catch (_err) {
+                console.error(`Dissonity NPM: Error attempting to subscribe to: ${event}. You may need some scope?`);
+            }
+            break;
+        }
+
+        case "UNSUBSCRIBE": {
+
+            if (event == null) {
+                throw new Error("UNSUBSCRIBE event is undefined");
+            }
+
+            //? Use channel id
+            if (args.channel_id) args = { channel_id: discordSdk!.channelId };
+
+            discordSdk!.unsubscribe(event as DiscordSDKEvents, handleSubscribeEvent);
+            break;
+        }
+
+        case "SET_ACTIVITY": {
+
+            //? No activity
+            if (!args.activity) {
+                throw new Error("No activity provided for SET_ACTIVITY");
+            }
+
+            //\ Clean unnecessary fields
+            if (args.activity.assets?.large_image == "") delete args.activity.assets;
+            if (args.activity.party?.id == "") delete args.activity.party;
+            if (args.activity.emoji?.id == "") delete args.activity.emoji;
+            if (args.activity.secrets?.match == "") delete args.activity.secrets;
+            
+            try {
+                const data = await discordSdk!.commands.setActivity(args);
+                getChildIframe().contentWindow?.postMessage({ nonce, event, command, data }, "*");
+
+            } catch (_err) {
+                console.error("Dissonity NPM: Error attempting to set the activity. You may need the 'rpc.activities.write' scope.")
+            }
+            break;
+        }
+
+        case "GET_INSTANCE_ID": {
+
+            const { instanceId } = discordSdk!;
+            getChildIframe().contentWindow?.postMessage({ nonce, command, data: instanceId, args }, "*");
+            break;
+        }
+
+        case "GET_CHANNEL_ID": {
+
+            const { channelId } = discordSdk!;
+            getChildIframe().contentWindow?.postMessage({ nonce, command, data: channelId, args }, "*");
+            break;
+        }
+
+        case "GET_GUILD_ID": {
+
+            const { guildId } = discordSdk!;
+            getChildIframe().contentWindow?.postMessage({ nonce, command, data: guildId, args }, "*");
+            break;
+        }
+
+        case "GET_USER_ID": {
+
+            getChildIframe().contentWindow?.postMessage({ nonce, command, data: user!.id, args }, "*");
+            break;
+        }
+
+        case "GET_USER": {
+
+            getChildIframe().contentWindow?.postMessage({ nonce, command, data: user!, args }, "*");
+            break;
+        }
+
+        case "GET_INSTANCE_PARTICIPANTS": {
+
+            const data = await discordSdk!.commands.getInstanceConnectedParticipants();
+            getChildIframe().contentWindow?.postMessage({ nonce, command, data, args }, "*");
+            break;
+        }
+
+        case "HARDWARE_ACCELERATION": {
+
+            const data = await discordSdk!.commands.encourageHardwareAcceleration();
+            getChildIframe().contentWindow?.postMessage({ nonce, command, data, args }, "*");
+            break;
+        }
+
+        case "GET_CHANNEL": {
+
+            //? No channel id
+            if (!args.channel_id) {
+                throw new Error("No channel id provided for GET_CHANNEL");
+            }
+
+            try {
+                const data = await discordSdk!.commands.getChannel(args);
+                getChildIframe().contentWindow?.postMessage({ nonce, command, data, args }, "*");
+
+            } catch (_err) {
+                console.error("Dissonity NPM: Error attempting to get the channel. You may need the 'guilds' scope.")
+            }
+
+            break;
+        }
+
+        case "GET_CHANNEL_PERMISSIONS": {
+
+            //? No channel id
+            if (!args.channel_id) {
+                throw new Error("No channel id provided for GET_CHANNEL_PERMISSIONS");
+            }
+
+            try {
+                const data = await discordSdk!.commands.getChannelPermissions(args);
+                getChildIframe().contentWindow?.postMessage({ nonce, command, data: stringifyBigInt(data), args }, "*");
+
+            } catch (_err) {
+                console.error("Dissonity NPM: Error attempting to get the channel permissions. You may need the 'guilds.members.read' scope.")
+            }
+
+            break;
+        }
+
+        case "GET_ENTITLEMENTS": {
+
+            throw new Error("Entitlements are not supported in Dissonity v1");
+
+            const data = await discordSdk!.commands.getEntitlements();
+            getChildIframe().contentWindow?.postMessage({ nonce, command, data, args }, "*");
+            break;
+        }
+
+        case "GET_PLATFORM_BEHAVIORS": {
+
+            const data = await discordSdk!.commands.getPlatformBehaviors();
+            getChildIframe().contentWindow?.postMessage({ nonce, command, data, args }, "*");
+            break;
+        }
+
+        case "GET_SKUS": {
+
+            throw new Error("Skus are not supported in Dissonity v1");
+
+            const data = await discordSdk!.commands.getSkus();
+            getChildIframe().contentWindow?.postMessage({ nonce, command, data, args }, "*");
+            break;
+        }
+
+        case "IMAGE_UPLOAD": {
+
+            try {
+                const url = await discordSdk!.commands.initiateImageUpload();
+                getChildIframe().contentWindow?.postMessage({ nonce, command, data: { image_url: url, canceled: false }, args }, "*");
+
+            } catch (_err) {
+                getChildIframe().contentWindow?.postMessage({ nonce, command, data: { image_url: "", canceled: true }, args }, "*");
+            }
+
+            break;
+        }
+
+        case "EXTERNAL_LINK": {
+
+            //? No url
+            if (!args.url) {
+                throw new Error("No url provided for EXTERNAL_LINK");
+            }
+
+            discordSdk!.commands.openExternalLink(args);
+            break;
+        }
+
+        case "INVITE_DIALOG": {
+
+            discordSdk!.commands.openInviteDialog();
+            break;
+        }
+
+        case "SHARE_MOMENT_DIALOG": {
+
+            //? No media url
+            if (!args.mediaUrl) {
+                throw new Error("No media url provided for SHARE_MOMENT_DIALOG");
+            }
+
+            discordSdk!.commands.openShareMomentDialog(args);
+            break;
+        }
+
+        case "SET_ORIENTATION_LOCK_STATE": {
+
+            //? No lock state
+            if (!args.lock_state) {
+                throw new Error("No lock state provided for SET_ORIENTATION_LOCK_STATE");
+            }
+
+            try {
+                discordSdk!.commands.setOrientationLockState(args);
+            } catch (_err) {
+                console.error("Dissonity NPM: Error attempting to set the orientation lock state. You may need the 'guilds.members.read' scope.")
+            }
+
+            break;
+        }
+
+        case "START_PURCHASE": {
+
+            throw new Error("Purchases are not supported in Dissonity v1");
+
+            discordSdk!.commands.startPurchase(args);
+            break;
+        }
+
+        case "GET_LOCALE": {
+
+            try {
+                const data = await discordSdk!.commands.userSettingsGetLocale();
+                getChildIframe().contentWindow?.postMessage({ nonce, command, data, args }, "*");
+
+            } catch (_err) {
+                console.error("Dissonity NPM: Error attempting to get the user locale. You may need the 'identify' scope.")
+            }
+
+            break;
+        }
+
+        case "SET_CONFIG": {
+
+            //? No field
+            if (!args.use_interactive_pip) {
+                throw new Error("No 'use interactive pip' provided for SET_CONFIG");
+            }
+
+            const data = await discordSdk!.commands.setConfig(args);
+            getChildIframe().contentWindow?.postMessage({ nonce, command, data, args }, "*");
+            break;
+        }
+
+        case "PING_LOAD": {
+
+            getChildIframe().contentWindow?.postMessage({ command: "LOADED", data: PACKAGE_VERSION }, "*");
+
+            break;
+        }
+    }
+}
+
 //\ Initialize the SDK and setup the bridge
 export async function setupSdk(options: ConfigOptions) {
+
+    if (initialized) throw new Error("Already initialized");
+
+    initialized = true;
 
     const dataPromise = initializeSdk(options);
     let discordSdk: DiscordSDK | null = null;
@@ -100,284 +388,7 @@ export async function setupSdk(options: ConfigOptions) {
             await dataPromise;
         }
 
-        const { nonce, event, command } = messageData;
-        let { args } = messageData;
-
-        // Sends a message to child iframe
-        function handleSubscribeEvent(eventData: Record<string, unknown>) {
-
-            getChildIframe().contentWindow?.postMessage(
-                {
-                    event,
-                    command: "DISPATCH",
-                    data: eventData,
-                },
-                "*"
-            );
-        }
-
-
-        // Handle the command
-        switch (command as MessageParentCommand) {
-
-            case "SUBSCRIBE": {
-
-                if (event == null) {
-                    throw new Error("SUBSCRIBE event is undefined");
-                }
-
-                //? Use channel id
-                if (args.channel_id) args = { channel_id: discordSdk!.channelId };
-
-                try {
-                    discordSdk!.subscribe(event as DiscordSDKEvents, handleSubscribeEvent, args as any);
-                } catch (_err) {
-                    console.error(`Dissonity NPM: Error attempting to subscribe to: ${event}. You may need some scope?`);
-                }
-                break;
-            }
-
-            case "UNSUBSCRIBE": {
-
-                if (event == null) {
-                    throw new Error("UNSUBSCRIBE event is undefined");
-                }
-
-                //? Use channel id
-                if (args.channel_id) args = { channel_id: discordSdk!.channelId };
-
-                discordSdk!.unsubscribe(event as DiscordSDKEvents, handleSubscribeEvent);
-                break;
-            }
-
-            case "SET_ACTIVITY": {
-
-                //? No activity
-                if (!args.activity) {
-                    throw new Error("No activity provided for SET_ACTIVITY");
-                }
-
-                //\ Clean unnecessary fields
-                if (args.activity.assets?.large_image == "") delete args.activity.assets;
-                if (args.activity.party?.id == "") delete args.activity.party;
-                if (args.activity.emoji?.id == "") delete args.activity.emoji;
-                if (args.activity.secrets?.match == "") delete args.activity.secrets;
-                
-                try {
-                    const data = await discordSdk!.commands.setActivity(args);
-                    getChildIframe().contentWindow?.postMessage({ nonce, event, command, data }, "*");
-
-                } catch (_err) {
-                    console.error("Dissonity NPM: Error attempting to set the activity. You may need the 'rpc.activities.write' scope.")
-                }
-                break;
-            }
-
-            case "GET_INSTANCE_ID": {
-
-                const { instanceId } = discordSdk!;
-                getChildIframe().contentWindow?.postMessage({ nonce, command, data: instanceId, args }, "*");
-                break;
-            }
-
-            case "GET_CHANNEL_ID": {
-
-                const { channelId } = discordSdk!;
-                getChildIframe().contentWindow?.postMessage({ nonce, command, data: channelId, args }, "*");
-                break;
-            }
-
-            case "GET_GUILD_ID": {
-
-                const { guildId } = discordSdk!;
-                getChildIframe().contentWindow?.postMessage({ nonce, command, data: guildId, args }, "*");
-                break;
-            }
-
-            case "GET_USER_ID": {
-
-                getChildIframe().contentWindow?.postMessage({ nonce, command, data: user!.id, args }, "*");
-                break;
-            }
-
-            case "GET_USER": {
-
-                getChildIframe().contentWindow?.postMessage({ nonce, command, data: user!, args }, "*");
-                break;
-            }
-
-            case "GET_INSTANCE_PARTICIPANTS": {
-
-                const data = await discordSdk!.commands.getInstanceConnectedParticipants();
-                getChildIframe().contentWindow?.postMessage({ nonce, command, data, args }, "*");
-                break;
-            }
-
-            case "HARDWARE_ACCELERATION": {
-
-                const data = await discordSdk!.commands.encourageHardwareAcceleration();
-                getChildIframe().contentWindow?.postMessage({ nonce, command, data, args }, "*");
-                break;
-            }
-
-            case "GET_CHANNEL": {
-
-                //? No channel id
-                if (!args.channel_id) {
-                    throw new Error("No channel id provided for GET_CHANNEL");
-                }
-
-                try {
-                    const data = await discordSdk!.commands.getChannel(args);
-                    getChildIframe().contentWindow?.postMessage({ nonce, command, data, args }, "*");
-
-                } catch (_err) {
-                    console.error("Dissonity NPM: Error attempting to get the channel. You may need the 'guilds' scope.")
-                }
-
-                break;
-            }
-
-            case "GET_CHANNEL_PERMISSIONS": {
-
-                //? No channel id
-                if (!args.channel_id) {
-                    throw new Error("No channel id provided for GET_CHANNEL_PERMISSIONS");
-                }
-
-                try {
-                    const data = await discordSdk!.commands.getChannelPermissions(args);
-                    getChildIframe().contentWindow?.postMessage({ nonce, command, data: stringifyBigInt(data), args }, "*");
-
-                } catch (_err) {
-                    console.error("Dissonity NPM: Error attempting to get the channel permissions. You may need the 'guilds.members.read' scope.")
-                }
-
-                break;
-            }
-
-            case "GET_ENTITLEMENTS": {
-
-                throw new Error("Entitlements are not yet available for the developer preview");
-
-                const data = await discordSdk!.commands.getEntitlements();
-                getChildIframe().contentWindow?.postMessage({ nonce, command, data, args }, "*");
-                break;
-            }
-
-            case "GET_PLATFORM_BEHAVIORS": {
-
-                const data = await discordSdk!.commands.getPlatformBehaviors();
-                getChildIframe().contentWindow?.postMessage({ nonce, command, data, args }, "*");
-                break;
-            }
-
-            case "GET_SKUS": {
-
-                throw new Error("Skus are not yet available for the developer preview");
-
-                const data = await discordSdk!.commands.getSkus();
-                getChildIframe().contentWindow?.postMessage({ nonce, command, data, args }, "*");
-                break;
-            }
-
-            case "IMAGE_UPLOAD": {
-
-                try {
-                    const url = await discordSdk!.commands.initiateImageUpload();
-                    getChildIframe().contentWindow?.postMessage({ nonce, command, data: { image_url: url, canceled: false }, args }, "*");
-
-                } catch (_err) {
-                    getChildIframe().contentWindow?.postMessage({ nonce, command, data: { image_url: "", canceled: true }, args }, "*");
-                }
-
-                break;
-            }
-
-            case "EXTERNAL_LINK": {
-
-                //? No url
-                if (!args.url) {
-                    throw new Error("No url provided for EXTERNAL_LINK");
-                }
-
-                discordSdk!.commands.openExternalLink(args);
-                break;
-            }
-
-            case "INVITE_DIALOG": {
-
-                discordSdk!.commands.openInviteDialog();
-                break;
-            }
-
-            case "SHARE_MOMENT_DIALOG": {
-
-                //? No media url
-                if (!args.mediaUrl) {
-                    throw new Error("No media url provided for SHARE_MOMENT_DIALOG");
-                }
-
-                discordSdk!.commands.openShareMomentDialog(args);
-                break;
-            }
-
-            case "SET_ORIENTATION_LOCK_STATE": {
-
-                //? No lock state
-                if (!args.lock_state) {
-                    throw new Error("No lock state provided for SET_ORIENTATION_LOCK_STATE");
-                }
-
-                try {
-                    discordSdk!.commands.setOrientationLockState(args);
-                } catch (_err) {
-                    console.error("Dissonity NPM: Error attempting to set the orientation lock state. You may need the 'guilds.members.read' scope.")
-                }
-
-                break;
-            }
-
-            case "START_PURCHASE": {
-
-                throw new Error("Purchases are not yet available for the developer preview");
-
-                discordSdk!.commands.startPurchase(args);
-                break;
-            }
-
-            case "GET_LOCALE": {
-
-                try {
-                    const data = await discordSdk!.commands.userSettingsGetLocale();
-                    getChildIframe().contentWindow?.postMessage({ nonce, command, data, args }, "*");
-
-                } catch (_err) {
-                    console.error("Dissonity NPM: Error attempting to get the user locale. You may need the 'identify' scope.")
-                }
-
-                break;
-            }
-
-            case "SET_CONFIG": {
-
-                //? No field
-                if (!args.use_interactive_pip) {
-                    throw new Error("No 'use interactive pip' provided for SET_CONFIG");
-                }
-
-                const data = await discordSdk!.commands.setConfig(args);
-                getChildIframe().contentWindow?.postMessage({ nonce, command, data, args }, "*");
-                break;
-            }
-
-            case "PING_LOAD": {
-
-                getChildIframe().contentWindow?.postMessage({ command: "LOADED", data: PACKAGE_VERSION }, "*");
-
-                break;
-            }
-        }
+        receiveMessage(discordSdk!, user!, messageData);
     }
 
     //\ Setup message event handler
@@ -390,3 +401,45 @@ export async function setupSdk(options: ConfigOptions) {
 
     getChildIframe().contentWindow?.postMessage({ command: "LOADED", data: PACKAGE_VERSION }, "*");
 }
+
+//\ Use external data and setup bridge
+export async function useSdk(dataPromise: DataPromise) {
+
+    if (initialized) throw new Error("Already initialized");
+
+    initialized = true;
+
+    let discordSdk: DiscordSDK | null = null;
+    let user: CompatibleUser | null = null;
+
+    async function handleMessage({ data: messageData }: MessageEvent<MessageData>) {
+
+        // Discard empty objects
+        if (typeof messageData !== "object" || Array.isArray(messageData) || messageData === null) {
+            return;
+        }
+
+        //? Not yet resolved
+        if (!discordSdk! || !user) {
+            await dataPromise;
+        }
+
+        receiveMessage(discordSdk!, user!, messageData);
+    }
+
+    //\ Setup message event handler
+    window.addEventListener("message", handleMessage);
+
+    // Wait for promise resolution
+    const resolvedData = await dataPromise;
+    discordSdk = resolvedData.discordSdk;
+
+    // Better compatibility with the SDKBridge
+    user = {...resolvedData.user} as CompatibleUser;
+    user.flags = user.public_flags;
+    user.bot = false;
+
+    getChildIframe().contentWindow?.postMessage({ command: "LOADED", data: PACKAGE_VERSION }, "*");
+}
+
+export { DiscordSDK };

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -47,5 +47,5 @@ export interface CompatibleUser {
 
 export type DataPromise = Promise<{
   discordSdk: DiscordSDK,
-  user: AuthUser
+  user: AuthUser | null
 }>;

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -13,6 +13,7 @@ export type ConfigOptions = {
 //# DISCORD DATA - - - - -
 export type DiscordSDKEvents = Parameters<DiscordSDK["subscribe"]>[0];
 export type ScopeArgument = Parameters<DiscordSDK["commands"]["authorize"]>[0]["scope"];
+export type AuthUser = Awaited<ReturnType<DiscordSDK["commands"]["authenticate"]>>["user"];
 
 // Represents the commands sent to the parent iframe or the child iframe
 export type MessageChildCommand = "LOADED" | "DISPATCH" | "GET_INSTANCE_ID" | "SET_ACTIVITY" | "GET_CHANNEL_ID" | "GET_GUILD_ID" | "GET_USER" | "GET_USER_ID"
@@ -43,3 +44,8 @@ export interface CompatibleUser {
   flags: number;
   bot: boolean;
 }
+
+export type DataPromise = Promise<{
+  discordSdk: DiscordSDK,
+  user: AuthUser
+}>;


### PR DESCRIPTION
This pull request adds support for using an external SDK instance to improve compatibility with the [Robo.js](https://github.com/Wave-Play/robo.js) framework.

## New exports
- `DiscordSDK`: class
- `useSdk`: function
- `DataPromise`: type

## Explanation

Dissonity v1 needs to have an instance and a user object to provide functionality. By the time the Unity build loads, the message handler has to be already awaiting the data. If `useSdk` was called once the authentication was done (and you had access to the user object), messages sent by Unity until then would be lost.

This is avoided by passing a promise to `useSdk` that will resolve once authentication is done. That way, messages sent by Unity before authentication are left pending until the promise is resolved.

The `DataPromise` type represents the shape this promise needs to have.

## Use


`index.ts`
```ts
import { useSdk, DiscordSDK, DataPromise } from "dissonity";

window.addEventListener("DOMContentLoaded", async () => {

    const promise: DataPromise = new Promise(async resolve => {
    
        const discordSdk = new DiscordSDK(/* Client id */);
        await discordSdk.ready();
  
        // (Authorization process...)
  
        const { user } = await discordSdk.commands.authenticate({
            access_token: /* Retrieved access token */,
        });

        resolve({ discordSdk, user });
    });

  useSdk(promise);
});
```

## TODO

- Update example server to use v1.3.0
- Add documentation