### PR TITLE
allow for null accent color

### DIFF
--- a/unity/Runtime/Models/AuthenticatedUser.cs
+++ b/unity/Runtime/Models/AuthenticatedUser.cs
@@ -13,7 +13,7 @@ namespace Dissonity.Models
         public string? GlobalName { get; set; }
 
         [JsonProperty("accent_color")]
-        public int AccentColor { get; set; }
+        public int? AccentColor { get; set; }
 
         [JsonProperty("avatar_decoration_data")]
         public AvatarDecoration? AvatarDecoration { get; set; }

--- a/unity/Runtime/Models/User.cs
+++ b/unity/Runtime/Models/User.cs
@@ -13,7 +13,7 @@ namespace Dissonity.Models
         public string? GlobalName { get; set; }
 
         [JsonProperty("accent_color")]
-        public int AccentColor { get; set; }
+        public int? AccentColor { get; set; }
 
         [JsonProperty("avatar_decoration_data")]
         public AvatarDecoration? AvatarDecoration { get; set; }


### PR DESCRIPTION
I caught this stack trace while testing. Discord documentation also notes that `accent_color` is nullable. https://discord.com/developers/docs/resources/user

```
InvalidCastException: Null object cannot be converted to a value type.
  at System.Convert.ChangeType (System.Object value, System.Type conversionType, System.IFormatProvider provider) [0x00000] in <00000000000000000000000000000000>:0 
Rethrow as JsonSerializationException: Error converting value {null} to type 'System.Int32'. Path 'data.user.accent_color'.
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureType (Newtonsoft.Json.JsonReader reader, System.Object value, System.Globalization.CultureInfo culture, Newtonsoft.Json.Serialization.JsonContract contract, System.Type targetType) [0x00000] in <00000000000000000000000000000000>:0 
```