### PR TITLE
expose access token

### DIFF
--- a/unity/Resources/WebGLTemplates/Dissonity/Files/Scripts/rpc_bridge.js.txt
+++ b/unity/Resources/WebGLTemplates/Dissonity/Files/Scripts/rpc_bridge.js.txt
@@ -386,7 +386,7 @@ function OverrideConsoleLogging() {
 }
 function InternalSend(message) {
     const source = window.parent.opener ?? window.parent;
-    const sourceOrigin = !!document.referrer ? document.referrer : "*";
+    const sourceOrigin = !!document.referrer ? new URL(document.referrer).origin : "*";
     source.postMessage(message, sourceOrigin);
 }
 function DispatchMultiEvent() {

--- a/unity/Runtime/DissonityApi.cs
+++ b/unity/Runtime/DissonityApi.cs
@@ -35,6 +35,7 @@ namespace Dissonity
         //# FIELDS - - - - -
         internal static long? _clientId;
         internal static string? _instanceId;
+        internal static string? _accessToken;
         internal static string? _platform;
         internal static long? _guildId;
         internal static long? _channelId;
@@ -99,6 +100,19 @@ namespace Dissonity
                 if (_mock) return GameObject.FindAnyObjectByType<DiscordMock>()._query.InstanceId;
 
                 return _instanceId!;
+            }
+        }
+        
+        /// <summary>
+        /// Your client access token
+        /// </summary>
+        public static string? AccessToken
+        {
+            get
+            {
+                if (!_ready) throw new InvalidOperationException("You can't access this property before waiting for Api.Initialize");
+
+                return _accessToken;
             }
         }
         
@@ -1946,7 +1960,8 @@ namespace Dissonity
 
                 // OverrideConsoleLogging is done in the BridgeLib
                 _userId = multiEvent.AuthenticateData.User.Id;
-
+                _accessToken = multiEvent.AuthenticateData.AccessToken;
+                
                 //? Synchronize user
                 if (_configuration!.SynchronizeUser)
                 {

--- a/unity/Runtime/DissonityApi.cs
+++ b/unity/Runtime/DissonityApi.cs
@@ -2082,8 +2082,11 @@ namespace Dissonity
             {
                 payload = command;
             }
-
-            string stringifiedMessage = JsonConvert.SerializeObject(new object[2] { command.Opcode, payload });
+            var settings = new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+            };
+            string stringifiedMessage = JsonConvert.SerializeObject(new object[2] { command.Opcode, payload }, settings);
 
             if (!isEditor)
             {

--- a/unity/Runtime/Models/ActivityParty.cs
+++ b/unity/Runtime/Models/ActivityParty.cs
@@ -9,7 +9,7 @@ namespace Dissonity.Models
         #nullable enable annotations
 
         [JsonProperty("id")]
-        public long? Id { get; set; }
+        public string? Id { get; set; }
         
         [JsonProperty("size", NullValueHandling = NullValueHandling.Ignore)]
         public int[] Size { get; set; } = new int[0];

--- a/unity/Runtime/Models/Builders/ActivityBuilder.cs
+++ b/unity/Runtime/Models/Builders/ActivityBuilder.cs
@@ -10,6 +10,9 @@ namespace Dissonity.Models.Builders
     public class ActivityBuilder
     {
         #nullable enable annotations
+        
+        [JsonProperty("name")]
+        public string Name { get; set; }
 
         [JsonProperty("type")]
         public ActivityType Type { get; set; }
@@ -39,7 +42,7 @@ namespace Dissonity.Models.Builders
         {
             return new Activity()
             {
-                Name = "Activity Name",
+                Name = Name,
                 Type = Type,
                 Timestamps = Timestamps,
                 Details = Details,

--- a/unity/Runtime/Models/Timeframe.cs
+++ b/unity/Runtime/Models/Timeframe.cs
@@ -7,9 +7,9 @@ namespace Dissonity.Models
     public class Timeframe
     {
         [JsonProperty("start")]
-        public int? Start { get; set; }
+        public long? Start { get; set; }
 
         [JsonProperty("end")]
-        public int? End { get; set; }
+        public long? End { get; set; }
     }
 }


### PR DESCRIPTION
Exposing the access token allows a developer to use it in API calls to Discord Rest API from Unity.

For example:
```c#
using Discord.Rest;
...
DiscordRestClient = new DiscordRestClient();
await DiscordRestClient.LoginAsync(TokenType.Bearer, ConnectionData.DiscordToken);
...
```