### PR TITLE
[BUG] Race condition creates multiple rooms

### DIFF
--- a/examples/MultiplayerExample.cs
+++ b/examples/MultiplayerExample.cs
@@ -17,13 +17,12 @@ public class MyScript : MonoBehaviour
         string instanceId = await GetSDKInstanceId();
         string userId = await GetUserId();
 
-        //\ Connect to matchmaking room
-        // (This implementation can be improved, but this should do)
+        //\ Connect to server
         client = new ColyseusClient("wss://<your-app-id>.discordsays.com/.proxy");
 
         //\ Create or join the activity room
         room = await client.JoinOrCreate<GameState>("game", new Dictionary<string, object>{
-            { "instanceId", instanceId }, 
+            { "instanceId", instanceId },
             { "userId", userId }
         });
 

--- a/examples/MultiplayerExample.cs
+++ b/examples/MultiplayerExample.cs
@@ -20,31 +20,13 @@ public class MyScript : MonoBehaviour
         //\ Connect to matchmaking room
         // (This implementation can be improved, but this should do)
         client = new ColyseusClient("wss://<your-app-id>.discordsays.com/.proxy");
-        var matchmakingRoom = await client.Create<MatchmakingState>("matchmaking", new Dictionary<string, object>{{ "instanceId", instanceId }});
 
-        // Listen for matchmaking room instructions
-        matchmakingRoom.OnMessage<Dictionary<string, object>>("matchmake", async data => {
-
-            //\ Leave matchmaking room
-            await matchmakingRoom.Leave();
-
-            //? Room already exists
-            if ((bool) data["exists"]) {
-
-                //\ Join the existing activity room
-                room = await client.JoinById<GameState>(instanceId, new Dictionary<string, object>{{ "userId", userId }});
-
-                // Client is now connected to the room!
-            }
-
-            //? Doesn't exist
-            else {
-
-                //\ Create the activity room
-                room = await client.Create<GameState>("game", new Dictionary<string, object>{{ "instanceId", instanceId }, { "userId", userId }});
-
-                // Client is now connected to the room!
-            }
+        //\ Create or join the activity room
+        room = await client.JoinOrCreate<GameState>("game", new Dictionary<string, object>{
+            { "instanceId", instanceId }, 
+            { "userId", userId }
         });
+
+        // Client is now connected to the room!
     }
 }

--- a/examples/node_project/package.json
+++ b/examples/node_project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dissonity-base-project",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Dissonity example Node.js app",
   "scripts": {
     "colyseus": "npx schema-codegen src/server/utils/structures.ts --csharp --output _unity_colyseus/",

--- a/examples/node_project/src/server/index.ts
+++ b/examples/node_project/src/server/index.ts
@@ -86,7 +86,7 @@ if (process.env.COLYSEUS!.toLowerCase() == "true") {
     .filterBy(["instanceId"]);
     
   colyseusServer.define("game", GameRoom)
-  .filterBy(["instanceId", "userId"]);
+  .filterBy(["instanceId"]);
   
   //\ Listen to port
   colyseusServer.listen(Number(process.env.PORT!));

--- a/examples/node_project/src/server/index.ts
+++ b/examples/node_project/src/server/index.ts
@@ -80,10 +80,6 @@ if (process.env.COLYSEUS!.toLowerCase() == "true") {
       server: createServer(app)
     })
   });
-  
-  //\ Expose the rooms
-  colyseusServer.define("matchmaking", MatchmakingRoom)
-    .filterBy(["instanceId"]);
     
   colyseusServer.define("game", GameRoom)
   .filterBy(["instanceId"]);

--- a/examples/node_project/src/server/index.ts
+++ b/examples/node_project/src/server/index.ts
@@ -9,7 +9,7 @@ import express from "express";
 import { Server } from "colyseus";
 import { createServer } from "http";
 import { WebSocketTransport } from "@colyseus/ws-transport";
-import { MatchmakingRoom, GameRoom } from "./utils/rooms";
+import { GameRoom } from "./utils/rooms";
 
 
 //\ Prepare express server
@@ -81,6 +81,7 @@ if (process.env.COLYSEUS!.toLowerCase() == "true") {
     })
   });
     
+  //\ Expose room
   colyseusServer.define("game", GameRoom)
   .filterBy(["instanceId"]);
   

--- a/examples/node_project/src/server/utils/rooms.ts
+++ b/examples/node_project/src/server/utils/rooms.ts
@@ -12,39 +12,6 @@ import type { ExpectedCreateOptions, ExpectedJoinOptions } from "./types";
 // Used to keep track of existing rooms. The keys are activity instance ids.
 const roomsMap = new Map<string, boolean>();
 
-// Users can connect to this room to know whether they have to create a new room
-// or connect to an existing one. They'll connect, receive instructions and disconnect.
-export class MatchmakingRoom extends Room {
-    override maxClients: number = 1;
-
-    private disconnectTimeout: NodeJS.Timeout | null = null;
-
-    override onCreate(options: ExpectedCreateOptions): void | Promise<any> {
-        
-        //? Check validity
-        if (typeof options.instanceId != "string") return this.disconnect();
-
-        //\ Set state
-        this.setState(new MatchmakingState());
-    }
-
-    override onJoin(client: Client, options: Required<ExpectedCreateOptions>): void | Promise<any> {
-
-        // Client should receive the instructions and disconnect before 5s
-        this.disconnectTimeout = setTimeout(() => { client.leave(); }, 5_000);
-        
-        //? Room exists
-        const roomValue = roomsMap.get(options.instanceId);
-        client.send("matchmake", {
-            exists: roomValue ?? false,
-        });
-    }
-
-    override onLeave(_client: Client, _consented?: boolean): void | Promise<any> {
-        clearTimeout(this.disconnectTimeout as NodeJS.Timeout);
-    }
-}
-
 // This is your actual game room!
 export class GameRoom extends Room {
 

--- a/examples/node_project/src/server/utils/rooms.ts
+++ b/examples/node_project/src/server/utils/rooms.ts
@@ -4,7 +4,7 @@
  */
 
 import { Room } from "colyseus";
-import { GameState, MatchmakingState, Player } from "./structures";
+import { GameState, Player } from "./structures";
 
 import type { Client } from "colyseus";
 import type { ExpectedCreateOptions, ExpectedJoinOptions } from "./types";
@@ -12,7 +12,7 @@ import type { ExpectedCreateOptions, ExpectedJoinOptions } from "./types";
 // Used to keep track of existing rooms. The keys are activity instance ids.
 const roomsMap = new Map<string, boolean>();
 
-// This is your actual game room!
+// This is your game room!
 export class GameRoom extends Room {
 
     override onCreate(options: ExpectedCreateOptions): void | Promise<any> {

--- a/examples/node_project/src/server/utils/structures.ts
+++ b/examples/node_project/src/server/utils/structures.ts
@@ -16,9 +16,6 @@ export class Player extends Schema {
     userId: string = "";
 }
 
-// Matchmaking doesn't require state
-export class MatchmakingState extends Schema {}
-
 // Example game state
 export class GameState extends Schema {
 


### PR DESCRIPTION
The MatchmakingRoom approach has a bug that whenever two people join the activity at the same time, they both receive that it does not exist yet, so they both create a new room. This is really annoying especially when testing at unity editor, as multiplayer play mode always start them simultaneously. Luckily, there's a simple way to solve it, and simplify the code at the same time.
Using client.JoinOrCreate and altering the room filter to only instance id (as if it was userId too it would create a new room per instanceId, per userId, and we want a new room per instanceId only), it already solves it automatically, as there's no connection time gap.

Sorry if I'm against the contributing guidelines, but I didn't find any, so if you have any considerations please just say it.